### PR TITLE
Settings file added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+SETTINGS.txt


### PR DESCRIPTION
Generally, people are going to have their own custom settings file.  Setting git to ignore it by default is generally a good idea.  If you update the format it can be explicitly added to git very easily.